### PR TITLE
Hotfix/ObjectStorage asset could not be saved

### DIFF
--- a/Assets/SODatabase/Editor/DataObject/ObjectStorage/CS/ObjectStorageEditor.cs
+++ b/Assets/SODatabase/Editor/DataObject/ObjectStorage/CS/ObjectStorageEditor.cs
@@ -38,6 +38,11 @@ namespace SODatabase.Editor
 
             return root;
         }
+        public void OnDisable()
+        {
+            var storage = (ObjectStorage)target;
+            EditorUtility.SetDirty(storage);
+        }
 
 
         // VisualElementフィールドを定義

--- a/Assets/SODatabase/Editor/SODatabase.Editor.asmdef
+++ b/Assets/SODatabase/Editor/SODatabase.Editor.asmdef
@@ -11,10 +11,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_EDITOR"
-    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
## 概要
エディターから編集したとき、変更が保存されない問題を修正しました。


## 詳細
- ObjectStorageEditor
OnDisableメソッド内でターゲットを保存待機状態にするように変更しました。


## 影響
この変更は影響を与えません。